### PR TITLE
Added support for many more `std::` types

### DIFF
--- a/Serializable.h
+++ b/Serializable.h
@@ -222,6 +222,20 @@ namespace BSerializer {
             : std::bool_constant<isSerializable<_T>::value> { };
 
         template <typename _T>
+        struct isStdOptional
+            : std::false_type { };
+        template <typename _T>
+        struct isStdOptional<std::optional<_T>>
+            : std::true_type { };
+
+        template <typename _T>
+        struct isSerializableStdOptional
+            : std::false_type { };
+        template <typename _T>
+        struct isSerializableStdOptional<std::optional<_T>>
+            : std::bool_constant<isSerializable<_T>::value> { };
+
+        template <typename _T>
         struct isSerializable
             : std::bool_constant<
                 std::is_arithmetic_v<_T> ||
@@ -231,6 +245,7 @@ namespace BSerializer {
                 isSerializableMap<_T>::value ||
                 isStdComplex<_T>::value ||
                 isSerializableStdArray<_T>::value ||
+                isSerializableStdOptional<_T>::value ||
                 BuiltInSerializable<_T>
             > { };
     }
@@ -316,6 +331,22 @@ namespace BSerializer {
     concept SerializableStdArray = details::isSerializableStdArray<_T>::value;
 
     /**
+     * @brief Concept to check if a type is any std::optional<...>.
+     *
+     * @tparam _T The type whose conformity is evaluated.
+     */
+    template <typename _T>
+    concept StdOptional = details::isStdOptional<_T>::value;
+
+    /**
+     * @brief Concept to check if a type is any std::optional<...> and if the conditionally wrapped type is (de)serializable by BSerializer.
+     *
+     * @tparam _T The type whose conformity is evaluated.
+     */
+    template <typename _T>
+    concept SerializableStdOptional = details::isSerializableStdOptional<_T>::value;
+
+    /**
      * @brief Concept to check if a type is serializable by BSerializer.
      * 
      * A type satisfies Serializable if it conforms to any of the following constraints:
@@ -326,6 +357,7 @@ namespace BSerializer {
      * - It satisfies BSerializer::SerializableMap (is a BSerializer::Map and the types of its keys and values are [de]serializable by BSerializer).
      * - It satisfies BSerializer::StdComplex (is any std::complex<...>).
      * - It satisfies BSerializer::SerializableStdArray (is any std::array<..., ...> and the types of its elements are [de]serializable by BSerializer).
+     * - It satisfies BSerializer::SerializableStdOptional (is any std::optional<...> and the conditionally wrapped type is [de]serializable by BSerializer).
      * - It satisfies BSerializer::BuiltInSerializable (has a preexisting [de]serializer that is compatible with BSerializer).
      * 
      * @tparam _T The type whose conformity is evaluated.

--- a/Serializable.h
+++ b/Serializable.h
@@ -199,6 +199,13 @@ namespace BSerializer {
             : std::bool_constant<isSerializable<typename _T::key_type>::value && isSerializable<typename _T::mapped_type>::value> { };
 
         template <typename _T>
+        struct isComplex
+            : std::false_type { };
+        template <typename _T>
+        struct isComplex<std::complex<_T>>
+            : std::true_type { };
+        
+        template <typename _T>
         struct isSerializable
             : std::bool_constant<
                 std::is_arithmetic_v<_T> ||
@@ -206,6 +213,7 @@ namespace BSerializer {
                 isSerializableStdTuple<_T>::value ||
                 isSerializableCollection<_T>::value ||
                 isSerializableMap<_T>::value ||
+                isComplex<_T>::value ||
                 BuiltInSerializable<_T>
             > { };
     }
@@ -267,6 +275,14 @@ namespace BSerializer {
     concept SerializableMap = details::isSerializableMap<_T>::value;
 
     /**
+     * @brief Concept to check if a type is any std::complex<...>.
+     *
+     * @tparam _T The type whose conformity is evaluated.
+     */
+    template <typename _T>
+    concept Complex = details::isComplex<_T>::value;
+
+    /**
      * @brief Concept to check if a type is serializable by BSerializer.
      * 
      * A type satisfies Serializable if it conforms to any of the following constraints:
@@ -275,6 +291,7 @@ namespace BSerializer {
      * - It satisfies BSerializer::SerializableStdTuple (is any std::tuple<...> and the types of its values are [de]serializable by BSerializer).
      * - It satisfies BSerializer::SerializableCollection (is a BSerializer::Collection and the types of its elements are [de]serializable by BSerializer).
      * - It satisfies BSerializer::SerializableMap (is a BSerializer::Map and the types of its keys and values are [de]serializable by BSerializer).
+     * - It satisfies BSerializer::Complex (is any std::complex<...>).
      * - It satisfies BSerializer::BuiltInSerializable (has a preexisting [de]serializer that is compatible with BSerializer).
      * 
      * @tparam _T The type whose conformity is evaluated.

--- a/Serializable.h
+++ b/Serializable.h
@@ -3,6 +3,7 @@
 #include <concepts>
 #include <complex>
 #include <array>
+#include <optional>
 
 namespace BSerializer {
     /**

--- a/Serializable.h
+++ b/Serializable.h
@@ -200,10 +200,10 @@ namespace BSerializer {
             : std::bool_constant<isSerializable<typename _T::key_type>::value && isSerializable<typename _T::mapped_type>::value> { };
 
         template <typename _T>
-        struct isComplex
+        struct isStdComplex
             : std::false_type { };
         template <typename _T>
-        struct isComplex<std::complex<_T>>
+        struct isStdComplex<std::complex<_T>>
             : std::true_type { };
         
         template <typename _T>
@@ -214,7 +214,7 @@ namespace BSerializer {
                 isSerializableStdTuple<_T>::value ||
                 isSerializableCollection<_T>::value ||
                 isSerializableMap<_T>::value ||
-                isComplex<_T>::value ||
+                isStdComplex<_T>::value ||
                 BuiltInSerializable<_T>
             > { };
     }
@@ -281,7 +281,7 @@ namespace BSerializer {
      * @tparam _T The type whose conformity is evaluated.
      */
     template <typename _T>
-    concept Complex = details::isComplex<_T>::value;
+    concept StdComplex = details::isStdComplex<_T>::value;
 
     /**
      * @brief Concept to check if a type is serializable by BSerializer.
@@ -292,7 +292,7 @@ namespace BSerializer {
      * - It satisfies BSerializer::SerializableStdTuple (is any std::tuple<...> and the types of its values are [de]serializable by BSerializer).
      * - It satisfies BSerializer::SerializableCollection (is a BSerializer::Collection and the types of its elements are [de]serializable by BSerializer).
      * - It satisfies BSerializer::SerializableMap (is a BSerializer::Map and the types of its keys and values are [de]serializable by BSerializer).
-     * - It satisfies BSerializer::Complex (is any std::complex<...>).
+     * - It satisfies BSerializer::StdComplex (is any std::complex<...>).
      * - It satisfies BSerializer::BuiltInSerializable (has a preexisting [de]serializer that is compatible with BSerializer).
      * 
      * @tparam _T The type whose conformity is evaluated.

--- a/Serializable.h
+++ b/Serializable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <concepts>
+#include <complex>
 
 namespace BSerializer {
     /**

--- a/Serializer.h
+++ b/Serializer.h
@@ -5,8 +5,6 @@
 #include <utility>
 #include <tuple>
 #include <exception>
-#include <array>
-#include <optional>
 #include "Serializable.h"
 
 namespace BSerializer {

--- a/Serializer.h
+++ b/Serializer.h
@@ -334,7 +334,7 @@ __forceinline size_t BSerializer::SerializedSize(const _T& Value) {
         }, Value);
         return t;
     }
-    else if constexpr (Complex<_T>) {
+    else if constexpr (StdComplex<_T>) {
         return sizeof(decltype(Value.real())) << 1;
     }
 }
@@ -407,7 +407,7 @@ __forceinline void BSerializer::Serialize(void*& Data, const _T& Value) {
             (Serialize(Data, args), ...);
         }, Value);
     }
-    else if constexpr (Complex<_T>) {
+    else if constexpr (StdComplex<_T>) {
         Serialize(Data, Value.real());
         Serialize(Data, Value.imag());
     }
@@ -507,7 +507,7 @@ __forceinline void BSerializer::Deserialize(const void*& Data, void* Value) {
     else if constexpr (SerializableStdTuple<_T>) {
         details::DeserializeTuple(Data, *(_T*)Value);
     }
-    else if constexpr (Complex<_T>) {
+    else if constexpr (StdComplex<_T>) {
         using component_t = decltype(std::declval<_T>().real());
         component_t re = Deserialize<component_t>(Data);
         component_t im = Deserialize<component_t>(Data);

--- a/Serializer.h
+++ b/Serializer.h
@@ -452,6 +452,12 @@ __forceinline size_t BSerializer::SerializedSize(const _T& Value) {
     else if constexpr (SerializableStdVariant<_T>) {
         return details::variantSerializedSize(Value);
     }
+    else if constexpr (StdDuration<_T>) {
+        return sizeof(decltype(Value.count()));
+    }
+    else if constexpr (StdTimePoint<_T>) {
+        return sizeof(decltype(Value.time_since_epoch().count()));
+    }
 }
 
 template <BSerializer::Serializable _T>
@@ -538,6 +544,12 @@ __forceinline void BSerializer::Serialize(void*& Data, const _T& Value) {
     }
     else if constexpr (SerializableStdVariant<_T>) {
         details::variantSerialize(Data, Value);
+    }
+    else if constexpr (StdDuration<_T>) {
+        Serialize(Data, Value.count());
+    }
+    else if constexpr (StdTimePoint<_T>) {
+        Serialize(Data, Value.time_since_epoch());
     }
 }
 
@@ -655,6 +667,14 @@ __forceinline void BSerializer::Deserialize(const void*& Data, void* Value) {
     }
     else if constexpr (SerializableStdVariant<_T>) {
         details::variantDeserialize(Data, (_T*)Value);
+    }
+    else if constexpr (StdDuration<_T>) {
+        using internal_t = decltype(std::declval<_T>().count());
+        new (Value) _T(Deserialize<internal_t>(Data));
+    }
+    else if constexpr (StdTimePoint<_T>) {
+        using internal_t = decltype(std::declval<_T>().time_since_epoch());
+        new (Value) _T(Deserialize<internal_t>(Data));
     }
 }
 

--- a/Serializer.h
+++ b/Serializer.h
@@ -5,7 +5,6 @@
 #include <utility>
 #include <tuple>
 #include <exception>
-#include <complex>
 #include "Serializable.h"
 
 namespace BSerializer {


### PR DESCRIPTION
Added support for all of the following:

* `std::optional<...>` (declared in header `<optional>`);
* `std::variant<...>` (declared in header `<variant>`);
* `std::chrono::duration` (declared in header `<chrono>`);
* `std::chrono::time_point` (declared in header `<chrono>`);
* `std::complex` (declared in header `<complex>`);
* `std::array<..., ...>` (declared in header `<array>`).

This pull request would close issue #1.