### PR TITLE
Added support for trivial types

### DIFF
--- a/Serializable.h
+++ b/Serializable.h
@@ -271,7 +271,7 @@ namespace BSerializer {
         template <typename _T>
         struct isSerializable
             : std::bool_constant<
-                std::is_arithmetic_v<_T> ||
+                std::is_trivial_v<_T> ||
                 isSerializableStdPair<_T>::value ||
                 isSerializableStdTuple<_T>::value ||
                 isSerializableCollection<_T>::value ||
@@ -293,6 +293,14 @@ namespace BSerializer {
      */
     template <typename _T>
     concept Arithmetic = std::is_arithmetic_v<_T>;
+
+    /**
+     * @brief Concept to check if a type is trivial.
+     *
+     * @tparam _T The type whose conformity is evaluated.
+     */
+    template <typename _T>
+    concept Trivial = std::is_trivial_v<_T>;
     
     /**
      * @brief Concept to check if a type is any std::pair<..., ...>.
@@ -418,7 +426,7 @@ namespace BSerializer {
      * @brief Concept to check if a type is serializable by BSerializer.
      * 
      * A type satisfies Serializable if it conforms to any of the following constraints:
-     * - It satisfies BSerializer::Arithmetic (is integral or floating-point).
+     * - It satisfies BSerializer::Trivial (is trivial).
      * - It satisfies BSerializer::SerializableStdPair (is any std::pair<..., ...> and the types of its values are [de]serializable by BSerializer).
      * - It satisfies BSerializer::SerializableStdTuple (is any std::tuple<...> and the types of its values are [de]serializable by BSerializer).
      * - It satisfies BSerializer::SerializableCollection (is a BSerializer::Collection and the types of its elements are [de]serializable by BSerializer).

--- a/Serializer.h
+++ b/Serializer.h
@@ -420,7 +420,7 @@ __forceinline size_t BSerializer::SerializedSize(const _T& Value) {
         }
         return t;
     }
-    else if constexpr (Arithmetic<_T>) {
+    else if constexpr (Trivial<_T>) {
         return sizeof(_T);
     }
     else if constexpr (SerializableStdPair<_T>) {
@@ -519,6 +519,10 @@ __forceinline void BSerializer::Serialize(void*& Data, const _T& Value) {
         memcpy(Data, &v2, sizeof(_T));
         Data = ((_T*)Data + 1);
     }
+    else if constexpr (Trivial<_T>) {
+        memcpy(Data, &Value, sizeof(_T));
+        Data = ((_T*)Data + 1);
+    }
     else if constexpr (SerializableStdPair<_T>) {
         Serialize(Data, Value.first);
         Serialize(Data, Value.second);
@@ -607,6 +611,10 @@ __forceinline void BSerializer::Deserialize(const void*& Data, void* Value) {
     }
     else if constexpr (Arithmetic<_T>) {
         new (Value) _T(ToFromLittleEndian(*(_T*)Data));
+        Data = ((_T*)Data) + 1;
+    }
+    else if constexpr (Trivial<_T>) {
+        memcpy(Value, Data, sizeof(_T));
         Data = ((_T*)Data) + 1;
     }
     else if constexpr (SerializableStdPair<_T>) {


### PR DESCRIPTION
Extended support for arithmetic types to trivial types. The in-build (de)serializers in types conforming to `BuiltInSerializable` will still have precedence, but any trivial type is now guaranteed to be serialized in some way or another.